### PR TITLE
Add SQLite booking storage and admin API updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+data.db

--- a/app/api/slots/route.ts
+++ b/app/api/slots/route.ts
@@ -1,21 +1,54 @@
 import { type NextRequest, NextResponse } from "next/server"
+import db from "@/lib/db"
+
+function getWeekStart(week: string | null): Date {
+  const now = new Date()
+  if (!week) {
+    const day = now.getUTCDay() || 7
+    now.setUTCDate(now.getUTCDate() - day + 1)
+    now.setUTCHours(0, 0, 0, 0)
+    return now
+  }
+  const [y, w] = week.split("-").map(Number)
+  const simple = new Date(Date.UTC(y, 0, 1 + (w - 1) * 7))
+  const day = simple.getUTCDay()
+  if (day <= 4) {
+    simple.setUTCDate(simple.getUTCDate() - day + 1)
+  } else {
+    simple.setUTCDate(simple.getUTCDate() + 8 - day)
+  }
+  simple.setUTCHours(0, 0, 0, 0)
+  return simple
+}
+
+function generateSlots(start: Date): string[] {
+  const slots: string[] = []
+  const times = ["18:00", "18:30", "19:00", "19:30"]
+  for (let d = 0; d < 5; d++) {
+    const base = new Date(start)
+    base.setUTCDate(start.getUTCDate() + d)
+    times.forEach((t) => {
+      const [h, m] = t.split(":").map(Number)
+      const slot = new Date(base)
+      slot.setUTCHours(h - 5, m - 30, 0, 0)
+      slots.push(slot.toISOString())
+    })
+  }
+  return slots
+}
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
   const week = searchParams.get("week")
+  const weekStart = getWeekStart(week)
+  const allSlots = generateSlots(weekStart)
 
-  // Mock available slots - in production, this would fetch from your database
-  // Format: ISO string timestamps for available 30-minute slots
-  const mockSlots = [
-    "2025-01-27T12:30:00.000Z", // Monday 18:00 LK time
-    "2025-01-27T13:00:00.000Z", // Monday 18:30 LK time
-    "2025-01-28T12:30:00.000Z", // Tuesday 18:00 LK time
-    "2025-01-28T14:00:00.000Z", // Tuesday 19:30 LK time
-    "2025-01-29T13:30:00.000Z", // Wednesday 19:00 LK time
-    "2025-01-30T12:30:00.000Z", // Thursday 18:00 LK time
-    "2025-01-30T13:00:00.000Z", // Thursday 18:30 LK time
-    "2025-01-31T13:30:00.000Z", // Friday 19:00 LK time
-  ]
+  const rows = db
+    .prepare("SELECT start FROM bookings WHERE start >= ? AND start < ?")
+    .all(weekStart.toISOString(), new Date(weekStart.getTime() + 7 * 86400000).toISOString())
+  const booked = new Set(rows.map((r: any) => r.start))
 
-  return NextResponse.json(mockSlots)
+  const available = allSlots.filter((s) => !booked.has(s))
+  return NextResponse.json(available)
 }
+

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,23 @@
+import Database from 'better-sqlite3'
+import path from 'path'
+import fs from 'fs'
+
+const DB_PATH = path.join(process.cwd(), 'data.db')
+
+// ensure directory exists
+try {
+  fs.mkdirSync(path.dirname(DB_PATH), { recursive: true })
+} catch {}
+
+const db = new Database(DB_PATH)
+
+db.exec(`CREATE TABLE IF NOT EXISTS bookings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  start TEXT UNIQUE NOT NULL,
+  end TEXT NOT NULL,
+  name TEXT,
+  email TEXT
+)`)
+
+export default db
+

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "better-sqlite3": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- install `better-sqlite3`
- add DB init helper
- refactor slot lookup to query DB
- insert bookings to DB and forward to webhook
- enable cancel/move endpoints with DB and token auth
- sync schedule page with new API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880809ac7208332a1750a6303770991